### PR TITLE
Add FriendRequest model and friends list to User schema

### DIFF
--- a/backend/src/models/FriendRequest.ts
+++ b/backend/src/models/FriendRequest.ts
@@ -1,0 +1,29 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+export interface IFriendRequest extends Document {
+  sender: mongoose.Types.ObjectId;
+  receiver: mongoose.Types.ObjectId;
+  status: 'pending' | 'accepted' | 'declined';
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const FriendRequestSchema: Schema = new Schema({
+  sender: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  receiver: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+  status: {
+    type: String,
+    enum: ['pending', 'accepted', 'declined'],
+    default: 'pending'
+  }
+}, {
+  timestamps: true,
+  versionKey: false
+});
+
+// Indexes for quicker lookups
+FriendRequestSchema.index({ sender: 1 });
+FriendRequestSchema.index({ receiver: 1 });
+FriendRequestSchema.index({ status: 1 });
+
+export default mongoose.model<IFriendRequest>('FriendRequest', FriendRequestSchema);

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -6,6 +6,10 @@ export interface IUser extends Document {
   nickname?: string;
   avatar?: string; // URL to avatar image or base64 data
   lastSeen?: Date;
+  friends?: {
+    friend: mongoose.Types.ObjectId;
+    level: number;
+  }[];
 }
 
 const UserSchema: Schema = new Schema({
@@ -31,7 +35,13 @@ const UserSchema: Schema = new Schema({
   lastSeen: {
     type: Date,
     default: Date.now
-  }
+  },
+  friends: [
+    {
+      friend: { type: Schema.Types.ObjectId, ref: 'User', required: true },
+      level: { type: Number, default: 1 }
+    }
+  ]
 }, {
   timestamps: true, // Automatically adds createdAt and updatedAt
   versionKey: false // Disable the __v field


### PR DESCRIPTION
## Summary
- add FriendRequest model with sender/receiver/status fields and indexes
- expand User schema with friends array referencing other users

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: tsc type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6897674679648321b666c74cf9a02a5b